### PR TITLE
Fix day counter reset and update for Paper 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'java'
-    id 'com.gradleup.shadow' version '8.3.0'
+    id 'com.gradleup.shadow' version '9.3.1'
     id("xyz.jpenilla.run-paper") version "2.3.1"
 }
 
 group = 'xyz.mayahive'
-version = '1.1.2'
+version = '1.1.3'
 
 repositories {
     mavenCentral()
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     implementation 'org.bstats:bstats-bukkit:3.1.0'
 }
 

--- a/src/main/java/xyz/mayahive/customDaytime/Utils/TimeUtils.java
+++ b/src/main/java/xyz/mayahive/customDaytime/Utils/TimeUtils.java
@@ -1,9 +1,9 @@
 package xyz.mayahive.customDaytime.Utils;
 
+import org.bukkit.GameRules;
 import xyz.mayahive.customDaytime.CustomDaytime;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
-import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
@@ -47,7 +47,7 @@ public class TimeUtils {
         if (!CustomDaytime.getInstance().getConfig().getBoolean("enableNightFastForward", true)) {return false;}
 
         // Get player sleeping percentage game rule value
-        Integer ruleValue = world.getGameRuleValue(GameRule.PLAYERS_SLEEPING_PERCENTAGE);
+        Integer ruleValue = world.getGameRuleValue(GameRules.PLAYERS_SLEEPING_PERCENTAGE);
         if (ruleValue == null) ruleValue = 100; // fallback
 
         double percentage = ruleValue / 100.0;

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,8 +1,10 @@
 name: CustomDaytime
-version: '1.1.2'
+version: '1.1.3'
 main: xyz.mayahive.customDaytime.CustomDaytime
 api-version: '1.21'
 authors:
   - Seedim
+contributors:
+  - PureLove
 description: Customise Minecraft's day-night-cycle
 folia-supported: true


### PR DESCRIPTION
### Summary

**Fixes**
- **TimeTickTask.java**  
  - Adjusted time handling so the Minecraft day counter no longer resets to 0 when using custom time progression.
- **TimeTickTask.java & TimeUtils.java**  
  - Updated gamerule usage to match the current Paper-preferred API.

**Maintenance**
- Updated to **Paper API 1.21.11**
- Updated **ShadowJar** to the latest version
- Added my username to **contributors**
- Bumped version to **1.1.3**

*Build tested on Paper 1.21.11 and Purpur 1.21.11*