### PR TITLE
Add Modrinth release pipeline and clean up multi-module build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+name: Publish to Modrinth
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Determine previous release tag
+        id: prev_tag
+        run: |
+          PREV=$(git describe --tags --abbrev=0 "${{ github.event.release.tag_name }}^" 2>/dev/null || true)
+          echo "tag=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Detect changed modules
+        if: steps.prev_tag.outputs.tag != ''
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          base: ${{ steps.prev_tag.outputs.tag }}
+          filters: |
+            paper:
+              - 'paper/**'
+              - 'common/**'
+              - 'api/**'
+              - 'gradle/libs.versions.toml'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+
+      - name: Build all modules
+        run: ./gradlew build
+
+      - name: Publish Paper
+        if: steps.prev_tag.outputs.tag == '' || steps.filter.outputs.paper == 'true'
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          CHANGELOG: ${{ github.event.release.body }}
+        run: ./gradlew :paper:modrinth

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,73 @@
+name: Verify version
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract versions
+        id: versions
+        run: |
+          set -euo pipefail
+          extract() {
+            grep -E '^[[:space:]]*version[[:space:]]*=' "$1" | head -1 \
+              | sed -E 's/.*"([^"]+)".*/\1/'
+          }
+
+          PR_VERSION=$(extract build.gradle.kts)
+          if [ -z "$PR_VERSION" ]; then
+            echo "::error file=build.gradle.kts::Could not extract version from build.gradle.kts on PR branch."
+            exit 1
+          fi
+
+          BASE_FILE=$(git show "origin/${{ github.base_ref }}:build.gradle.kts")
+          BASE_VERSION=$(echo "$BASE_FILE" | grep -E '^[[:space:]]*version[[:space:]]*=' | head -1 \
+            | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "$BASE_VERSION" ]; then
+            echo "::error::Could not extract version from build.gradle.kts on origin/${{ github.base_ref }}."
+            exit 1
+          fi
+
+          echo "pr=$PR_VERSION"   >> "$GITHUB_OUTPUT"
+          echo "base=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "PR:   $PR_VERSION"
+          echo "Base: $BASE_VERSION"
+
+      - name: Reject 'dev' in version
+        run: |
+          PR='${{ steps.versions.outputs.pr }}'
+          if echo "$PR" | grep -qi 'dev'; then
+            echo "::error file=build.gradle.kts::Version '$PR' contains 'dev' — must not be merged."
+            exit 1
+          fi
+
+      - name: Verify version is not lower
+        run: |
+          set -euo pipefail
+          PR='${{ steps.versions.outputs.pr }}'
+          BASE='${{ steps.versions.outputs.base }}'
+
+          if [ "$PR" = "$BASE" ]; then
+            echo "Version unchanged ($BASE) — OK."
+            exit 0
+          fi
+
+          LOWER=$(printf '%s\n%s\n' "$PR" "$BASE" | sort -V | head -1)
+          if [ "$LOWER" != "$BASE" ]; then
+            echo "::error file=build.gradle.kts::PR version ($PR) is lower than base version ($BASE). Version must only go up."
+            exit 1
+          fi
+
+          echo "PR version $PR > base version $BASE — OK."

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 plugins {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,13 +8,6 @@ plugins {
     id("java")
 }
 
-group = "xyz.mayahive.customdaytime"
-version = "2.0.0-SNAPSHOT"
-
-repositories {
-    mavenCentral()
-}
-
 val javaTarget = 21 // Sponge targets a minimum of Java 21
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(javaTarget))

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/CustomDaytime.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/CustomDaytime.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api;

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/model/PlatformType.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/model/PlatformType.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api.model;

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/model/WorldKey.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/model/WorldKey.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api.model;

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/platform/Platform.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/platform/Platform.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api.platform;

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformLogger.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformLogger.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api.platform;

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformScheduler.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformScheduler.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api.platform;

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformTask.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformTask.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api.platform;

--- a/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformWorld.java
+++ b/api/src/main/java/xyz/mayahive/customdaytime/api/platform/PlatformWorld.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.api.platform;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@
 subprojects {
 
     group = "xyz.mayahive.customdaytime"
-    version = "2.1.0"
+    version = "2.1.1"
 
     if (name != "api") {
         plugins.withId("java") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,11 +9,6 @@ subprojects {
     group = "xyz.mayahive.customdaytime"
     version = "2.1.0"
 
-    repositories {
-        mavenCentral()
-        maven("https://repo.papermc.io/repository/maven-public/")
-    }
-
     if (name != "api") {
         plugins.withId("java") {
             dependencies {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,19 +5,14 @@
  */
 
 plugins {
-    id("java")
     id("java-library")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
     api(project(":api"))
 
-    implementation(libs.configurate.hocon)
-    implementation(libs.gson)
+    compileOnlyApi(libs.configurate.hocon)
+    compileOnlyApi(libs.gson)
 }
 
 val javaTarget = 21 // Sponge targets a minimum of Java 21

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 plugins {

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/bootstrap/AbstractBootstrap.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/bootstrap/AbstractBootstrap.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.bootstrap;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/cache/WorldCache.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/cache/WorldCache.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.cache;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/context/CustomDaytimeContext.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/context/CustomDaytimeContext.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.context;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/Event.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/Event.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/EventBus.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/EventBus.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/EventListener.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/EventListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/listener/TimeSkipListener.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/listener/TimeSkipListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.listener;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/listener/WorldActivityListener.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/listener/WorldActivityListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.listener;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/listener/WorldLifeCycleListener.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/listener/WorldLifeCycleListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.listener;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/TimeSkipCause.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/TimeSkipCause.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.type;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/TimeSkipEvent.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/TimeSkipEvent.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.type;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldLoadEvent.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldLoadEvent.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.type;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldPlayerCountChangeEvent.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldPlayerCountChangeEvent.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.type;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldSleepingPlayerCountChangeEvent.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldSleepingPlayerCountChangeEvent.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.type;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldUnloadEvent.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/event/type/WorldUnloadEvent.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.event.type;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/registry/CommonEventRegistry.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/registry/CommonEventRegistry.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.registry;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/service/CommonInitializerService.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/service/CommonInitializerService.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.service;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/service/ConfigService.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/service/ConfigService.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.service;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/service/DebugService.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/service/DebugService.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.service;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/service/UpdateCheckerService.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/service/UpdateCheckerService.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.service;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/service/WorldInitializationService.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/service/WorldInitializationService.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.service;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/world/WorldTimeController.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/world/WorldTimeController.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.world;

--- a/common/src/main/java/xyz/mayahive/customdaytime/common/world/WorldTimeManager.java
+++ b/common/src/main/java/xyz/mayahive/customdaytime/common/world/WorldTimeManager.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.common.world;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ lombok = "1.18.42"
 configurate = "4.2.0"
 gson = "2.13.2"
 bstats = "3.1.0"
+minotaur = "2.+"
 
 # --- Build & Tooling ---
 shadow = "9.3.1"
@@ -34,3 +35,4 @@ run-paper = {id = "xyz.jpenilla.run-paper", version.ref = "run-paper"}
 plugin-yml = {id = "de.eldoria.plugin-yml.paper", version.ref = "plugin-yml"}
 spongegradle = {id = "org.spongepowered.gradle.plugin", version.ref = "spongegradle"}
 spongevanilla = {id = "org.spongepowered.gradle.vanilla", version.ref = "spongevanilla"}
+minotaur = { id = "com.modrinth.minotaur", version.ref = "minotaur" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,20 @@
+#
+#     Copyright (c) 2026 Seedim
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -1,21 +1,20 @@
 #!/bin/sh
 
 #
-# Copyright © 2015 the original authors.
+#     Copyright (c) 2026 Seedim
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 ##############################################################################

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -9,22 +9,17 @@ plugins {
     alias(libs.plugins.run.paper)
     alias(libs.plugins.shadow)
     alias(libs.plugins.plugin.yml)
-}
-
-repositories {
-    mavenCentral()
-    maven {
-        name = "papermc-repo"
-        url = uri("https://repo.papermc.io/repository/maven-public/")
-    }
+    alias(libs.plugins.minotaur)
 }
 
 dependencies {
     implementation(project(":common"))
 
     implementation(libs.bstats.bukkit)
+    implementation(libs.configurate.hocon)
 
-    compileOnly(libs.paper.api.get())
+    compileOnly(libs.paper.api)
+    compileOnly(libs.gson)
 }
 
 tasks {
@@ -70,11 +65,34 @@ tasks {
         dependsOn(shadowJar)
     }
 
+    jar {
+        enabled = false
+    }
+
     shadowJar {
+        archiveBaseName.set("CustomDaytimePaper")
+        archiveClassifier.set("")
         relocate("org.bstats", "xyz.mayahive.libs.bstats")
         relocate("org.spongepowered.configurate", "xyz.mayahive.customdaytime.lib.configurate")
         relocate("net.kyori.option", "xyz.mayahive.customdaytime.lib.kyori.option")
+        relocate("io.leangen.geantyref", "xyz.mayahive.customdaytime.lib.geantyref")
     }
+}
+
+modrinth {
+    token.set(System.getenv("MODRINTH_TOKEN"))
+    projectId.set("C7YliNqw")
+    versionNumber.set(version.toString())
+    versionType.set("release")
+    uploadFile.set(tasks.shadowJar)
+    gameVersions.addAll("26.1", "26.1.1", "26.1.2")
+    loaders.addAll("paper", "folia", "purpur")
+    syncBodyFrom = rootProject.file("README.md").readText()
+    changelog.set(System.getenv("CHANGELOG").takeUnless { it.isNullOrBlank() } ?: "No changelog provided")
+}
+
+tasks.modrinth {
+    dependsOn(tasks.modrinthSyncBody)
 }
 
 paper {

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 plugins {

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/CustomDaytimePaper.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/CustomDaytimePaper.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/BedActivityListener.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/BedActivityListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.listener;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/TimeSkipListener.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/TimeSkipListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.listener;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/WorldActivityListener.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/WorldActivityListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.listener;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/WorldListener.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/listener/WorldListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.listener;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperLogger.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperLogger.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.platform;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperPlatform.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperPlatform.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.platform;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperScheduler.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperScheduler.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.platform;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperTask.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperTask.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.platform;

--- a/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperWorld.java
+++ b/paper/src/main/java/xyz/mayahive/customdaytime/paper/platform/PaperWorld.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.paper.platform;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 pluginManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,21 @@ pluginManagement {
         maven {
             url = uri("https://repo.spongepowered.org/repository/maven-public/")
         }
+        gradlePluginPortal()
+    }
+}
+
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        mavenCentral()
+        maven("https://repo.papermc.io/repository/maven-public/") {
+            name = "papermc-repo"
+        }
+        maven("https://repo.spongepowered.org/repository/maven-public/") {
+            name = "spongepowered-repo"
+        }
     }
 }
 

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -14,15 +14,11 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
-repositories {
-    mavenCentral()
-    maven("https://repo.spongepowered.org/maven/") {
-        name = "spongepowered-repo"
-    }
-}
-
 dependencies {
     api(project(":common"))
+
+    compileOnly(libs.configurate.hocon)
+    compileOnly(libs.gson)
 }
 
 sponge {
@@ -71,18 +67,8 @@ tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
 }
 
-tasks {
-    assemble {
-        dependsOn(shadowJar)
-    }
-
-    shadowJar {
-        dependencies {
-            exclude(dependency("io.leangen.geantyref:.*"))
-            exclude(dependency("net.kyori:.*"))
-            exclude(dependency("org.spongepowered:.*"))
-        }
-    }
+tasks.assemble {
+    dependsOn(tasks.shadowJar)
 }
 
 minecraft {

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 import org.spongepowered.gradle.plugin.config.PluginLoaders

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/CustomDaytimeSponge.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/CustomDaytimeSponge.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/listener/SleepingListener.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/listener/SleepingListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.listener;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/listener/WorldActivityListener.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/listener/WorldActivityListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.listener;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/listener/WorldListener.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/listener/WorldListener.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.listener;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeLogger.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeLogger.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.platform;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongePlatform.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongePlatform.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.platform;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeScheduler.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeScheduler.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.platform;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeTask.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeTask.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.platform;

--- a/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeWorld.java
+++ b/sponge/src/main/java/xyz/mayahive/customdaytime/sponge/platform/SpongeWorld.java
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2026 Seedim
- * This file is part of Custom Daytime, which is licensed under GPL-3.0.
- * See the LICENSE file in the project root for full license text.
+ *     Copyright (c) 2026 Seedim
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package xyz.mayahive.customdaytime.sponge.platform;


### PR DESCRIPTION
## Changes
- Adds Modrinth release pipeline for Paper, triggered on GitHub release publish.                                                                                                                                                                  
- Adds PR-side version-check workflow (rejects "dev" and downgrades).
- Restructures multi-module build: centralized repos, `compileOnlyApi` pattern, Sponge's `shadowJar` exclusion block dropped.                                                                                                                     
- Renames shaded jar to `CustomDaytimePaper-<version>.jar`, adds geantyref relocation.
- Bumps project to 2.1.1 and refreshes GPL-3.0 license headers.